### PR TITLE
Fix for classic S_GET_USER_LIST

### DIFF
--- a/protocol/S_GET_USER_LIST.15.classic.def
+++ b/protocol/S_GET_USER_LIST.15.classic.def
@@ -90,4 +90,3 @@ array  characters
 - string    name
 - bytes     details
 - bytes     shape
-- string    guildName


### PR DESCRIPTION
It doesn't actually have guild name in it